### PR TITLE
适配Xcode12+

### DIFF
--- a/packages/@weex/plugins/build/src/ios/ios-builder.ts
+++ b/packages/@weex/plugins/build/src/ios/ios-builder.ts
@@ -39,6 +39,7 @@ export default class IosBuilder extends Builder {
       '-scheme': projectInfo.scheme,
       '-configuration': 'Debug',
       '-sdk': 'iphonesimulator',
+      '-destination': `"platform=iOS Simulator,id=${options.deviceId}"`,
       '-derivedDataPath': IOS_DERIVE_DATA_PATH,
     }
 

--- a/packages/@weex/plugins/build/src/ios/ios-builder.ts
+++ b/packages/@weex/plugins/build/src/ios/ios-builder.ts
@@ -39,6 +39,7 @@ export default class IosBuilder extends Builder {
       '-scheme': projectInfo.scheme,
       '-configuration': 'Debug',
       '-sdk': 'iphonesimulator',
+      '-arch': 'x86_64', // 与-destination可以任意保留一个
       '-destination': `"platform=iOS Simulator,id=${options.deviceId}"`,
       '-derivedDataPath': IOS_DERIVE_DATA_PATH,
     }

--- a/packages/@weex/plugins/device/src/ios/ios-devices.ts
+++ b/packages/@weex/plugins/device/src/ios/ios-devices.ts
@@ -62,9 +62,9 @@ export default class IosDevices extends Devices {
     return devices
   }
 
-  async launchById(id) {
+  async launchById(id: DeviceInfo['id']): Promise<String> {
     try {
-        await process_js_1.exec(`xcrun simctl boot ${id}`, {
+        await exec.exec(`xcrun simctl boot ${id}`, {
             event: this,
         });
     }

--- a/packages/@weex/plugins/device/src/ios/ios-devices.ts
+++ b/packages/@weex/plugins/device/src/ios/ios-devices.ts
@@ -62,7 +62,7 @@ export default class IosDevices extends Devices {
     return devices
   }
 
-  async launchById(id: DeviceInfo['id']): Promise<String> {.
+  async launchById(id: DeviceInfo['id']): Promise<String> {
     try {
         await exec.exec(`xcrun simctl boot ${id}`, {
             event: this,

--- a/packages/@weex/plugins/device/src/ios/ios-devices.ts
+++ b/packages/@weex/plugins/device/src/ios/ios-devices.ts
@@ -62,7 +62,7 @@ export default class IosDevices extends Devices {
     return devices
   }
 
-  async launchById(id: DeviceInfo['id']): Promise<String> {
+  async launchById(id: DeviceInfo['id']): Promise<String> {.
     try {
         await exec.exec(`xcrun simctl boot ${id}`, {
             event: this,

--- a/packages/@weex/plugins/run/src/base/runner.ts
+++ b/packages/@weex/plugins/run/src/base/runner.ts
@@ -153,7 +153,7 @@ export default class Runner extends EventEmitter {
       this.watchFileChange()
       this.emit(messageType.state, runnerState.watchFileChangeDone)
 
-      appPath = await this.buildNative(options)
+      appPath = await this.buildNative(Object.assign(this.config, options))
       this.emit(messageType.state, runnerState.buildNativeDone)
 
       await this.installAndLaunchApp(appPath)


### PR DESCRIPTION
由于Xcode12+去掉了xrun instruments命令，因此将用到该命令的地方均修改为可支持的命令

`xcrun instruments -s devices`  ->   `xcrun xctrace list devices`

`xcrun instruments -w ${id}` -> `xcrun simctl boot ${id}`